### PR TITLE
This adds ini sections as different argument groups

### DIFF
--- a/pacifica/configparser/__init__.py
+++ b/pacifica/configparser/__init__.py
@@ -40,13 +40,11 @@ class ConfigArgParser(object):
     @staticmethod
     def update_defaults(defaults, conf_file, action_groups):
         """Update the defaults from a config parser."""
-        if not conf_file:
-            return {}
         def_copy = deepcopy(defaults)
         config = ConfigArgParser.get_safe_parser(conf_file)
         for config_group in action_groups:
             def_copy.update(dict(config.items(config_group)))
-        def_copy.update(dict(config.items('Defaults')))
+        def_copy.update(dict(config.items('DEFAULT')))
         return def_copy
 
     @staticmethod

--- a/pacifica/configparser/__init__.py
+++ b/pacifica/configparser/__init__.py
@@ -13,16 +13,47 @@ except ImportError:  # pragma: no cover only one version of python will cover th
 import six
 
 
-# pylint: disable=too-few-public-methods
 class ConfigArgParser(object):
     """Pulls command line defaults from config file."""
+
+    @staticmethod
+    def get_safe_parser(conf_file):
+        """Return a safe config parser in versioned way."""
+        config = SafeConfigParser()
+        # seems python 2 uses readfp and python 3 uses read_file
+        # but pylint calls this as a deprecated method
+        # pylint: disable=deprecated-method
+        if six.PY2:  # pragma: no cover only with python 2
+            config.readfp(conf_file)
+        else:  # pragma: no cover only with python 3
+            config.read_file(conf_file)
+        # pylint: enable=deprecated-method
+        return config
+
+    @staticmethod
+    def get_action_group_titles(parser):
+        """Get the action group titles from a parser object."""
+        # pylint: disable=protected-access
+        return [x.title for x in parser._action_groups[2:] if hasattr(x, 'title')]
+        # pylint: enable=protected-access
+
+    @staticmethod
+    def update_defaults(defaults, conf_file, action_groups):
+        """Update the defaults from a config parser."""
+        if not conf_file:
+            return {}
+        def_copy = deepcopy(defaults)
+        config = ConfigArgParser.get_safe_parser(conf_file)
+        for config_group in action_groups:
+            def_copy.update(dict(config.items(config_group)))
+        def_copy.update(dict(config.items('Defaults')))
+        return def_copy
 
     @staticmethod
     def configargparser(parser, defaults, def_conf_file, env_prefix, argv=False):
         """Use defaults found in config file and return a Namespace."""
         if not argv:  # pragma: no cover within pytest
             argv = sys.argv
-        def_copy = deepcopy(defaults)
         config_parser = ArgumentParser(
             description='parse out the config file', add_help=False)
         config_parser.add_argument(
@@ -31,25 +62,12 @@ class ConfigArgParser(object):
             default=open(def_conf_file)
         )
         args, remaining_argv = config_parser.parse_known_args(argv)
-        if args.conf_file:
-            config = SafeConfigParser()
-            # seems python 2 uses readfp and python 3 uses read_file
-            # but pylint calls this as a deprecated method
-            # pylint: disable=deprecated-method
-            if six.PY2:  # pragma: no cover only with python 2
-                config.readfp(args.conf_file)
-            else:  # pragma: no cover only with python 3
-                config.read_file(args.conf_file)
-            # pylint: enable=deprecated-method
-            # pylint: disable=protected-access
-            for config_group in [x.title for x in parser._action_groups[2:] if hasattr(x, 'title')]:
-                def_copy.update(dict(config.items(config_group)))
-            # pylint: enable=protected-access
-            def_copy.update(dict(config.items('Defaults')))
+        action_group_titles = ConfigArgParser.get_action_group_titles(parser)
+        def_copy = ConfigArgParser.update_defaults(
+            defaults, args.conf_file, action_group_titles)
         for key in def_copy.keys():
             env_key = '{}_{}'.format(env_prefix.upper(), key.upper())
             if os.getenv(env_key, False):
                 def_copy[key] = os.getenv(env_key)
         parser.set_defaults(**def_copy)
         return parser.parse_args(remaining_argv)
-# pylint: enable=too-few-public-methods

--- a/pacifica/configparser/test/example.ini
+++ b/pacifica/configparser/test/example.ini
@@ -1,1 +1,1 @@
-[Defaults]
+[DEFAULT]

--- a/pacifica/configparser/test/group.ini
+++ b/pacifica/configparser/test/group.ini
@@ -1,4 +1,4 @@
-[Defaults]
+[DEFAULT]
 foo = 1234
 
 [group-a]

--- a/pacifica/configparser/test/group.ini
+++ b/pacifica/configparser/test/group.ini
@@ -1,0 +1,8 @@
+[Defaults]
+foo = 1234
+
+[group-a]
+bar = 5678
+
+[group-b]
+fiz = 5432

--- a/pacifica/configparser/test/setfoo.ini
+++ b/pacifica/configparser/test/setfoo.ini
@@ -1,2 +1,2 @@
-[Defaults]
+[DEFAULT]
 foo = baz

--- a/pacifica/configparser/test/test_configargparse.py
+++ b/pacifica/configparser/test/test_configargparse.py
@@ -92,3 +92,26 @@ class TestConfigArgParse(TestCase):
         )
         self.assertEqual(args.integers, [1, 2])
         self.assertEqual(args.foo, 'baz')
+
+    def test_empty_config_file(self):
+        """Test that defaults get overridden by config."""
+        args = ConfigArgParser.configargparser(
+            self._rtfm_example(), {}, join(dirname(realpath(__file__)), 'empty.ini'),
+            'PACIFICA_CONFIGPARSE',
+            ['1', '2']
+        )
+        self.assertEqual(args.integers, [1, 2])
+        self.assertEqual(args.foo, 'blah')
+
+    def test_notfound_config_file(self):
+        """Test that defaults get overridden by config."""
+        hit_exception = False
+        try:
+            ConfigArgParser.configargparser(
+                self._rtfm_example(), {}, join(dirname(realpath(__file__)), 'notthere.ini'),
+                'PACIFICA_CONFIGPARSE',
+                ['1', '2']
+            )
+        except FileNotFoundError:
+            hit_exception = True
+        self.assertTrue(hit_exception)

--- a/pacifica/configparser/test/test_configargparse.py
+++ b/pacifica/configparser/test/test_configargparse.py
@@ -31,6 +31,26 @@ class TestConfigArgParse(TestCase):
         )
         return parser
 
+    @classmethod
+    def _group_example(cls):
+        """Test argument groups and how it shows up in ini files."""
+        parser = cls._rtfm_example()
+        group_a = parser.add_argument_group('group-a')
+        group_b = parser.add_argument_group('group-b')
+        group_a.add_argument('--bar', help='bar help')
+        group_b.add_argument('--fiz', help='fiz help')
+        return parser
+
+    def test_group_example(self):
+        """Test config groups."""
+        args = ConfigArgParser.configargparser(
+            self._group_example(), {}, join(dirname(realpath(__file__)), 'group.ini'),
+            'PACIFICA_CONFIGPARSE',
+            ['1', '2']
+        )
+        self.assertEqual(args.fiz, '5432')
+        self.assertEqual(args.bar, '5678')
+
     def test_simple_parser(self):
         """Test the RTFM argparse example."""
         args = ConfigArgParser.configargparser(

--- a/pacifica/configparser/test/test_configargparse.py
+++ b/pacifica/configparser/test/test_configargparse.py
@@ -112,6 +112,6 @@ class TestConfigArgParse(TestCase):
                 'PACIFICA_CONFIGPARSE',
                 ['1', '2']
             )
-        except FileNotFoundError:
+        except IOError:
             hit_exception = True
         self.assertTrue(hit_exception)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 setuptools
+six


### PR DESCRIPTION
### Description

This allows an ini file to have multiple sections which provide
defaults for options in the respective parser groups.



### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
